### PR TITLE
IPS post processing, contained to separate entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - tests for IPS Medical Devices section (unverified mappings)
 - added a docker hub build action that builds arm64 compliant docker image
+- IPS post-processing logic, which makes sure Bundle produced is of type `document` and also adds Bundle profile and required Bundle identifier
+
+### Changed
+- engine now by default moves contained Resources to separate Bundle entries (can be changed by setting `openfhir.contained-to-separate-entities` to `false`)
 
 ## [2.2.1] - 2026-05-04
 

--- a/core/src/main/java/com/syntaric/openfhir/OpenFhirDefaultsConfig.java
+++ b/core/src/main/java/com/syntaric/openfhir/OpenFhirDefaultsConfig.java
@@ -35,7 +35,7 @@ public class OpenFhirDefaultsConfig {
     @Bean
     @ConditionalOnMissingBean(ToFhirPrePostProcessorInterface.class)
     public ToFhirPrePostProcessorInterface toFhirPrePostProcessor(final FhirContextRegistry fhirContextRegistry) {
-        return new ToFhirPrePostProcessor(fhirContextRegistry);
+        return new ToFhirPrePostProcessor(fhirContextRegistry, true);
     }
 
     @Bean

--- a/core/src/main/java/com/syntaric/openfhir/mapping/tofhir/ToFhir.java
+++ b/core/src/main/java/com/syntaric/openfhir/mapping/tofhir/ToFhir.java
@@ -29,7 +29,6 @@ import java.util.Map;
 public class ToFhir {
 
     final private FlatJsonMarshaller flatJsonMarshaller;
-    final private OpenEhrTemplateUtils openEhrApplicationScopedUtils;
     final private Gson gson;
     final private HelpersCreator helpersCreator;
     final private ToFhirPrePostProcessorInterface toFhirPrePostProcessor;
@@ -39,7 +38,6 @@ public class ToFhir {
 
     @Autowired
     public ToFhir(final FlatJsonMarshaller flatJsonMarshaller,
-                  final OpenEhrTemplateUtils openEhrApplicationScopedUtils,
                   final Gson gson,
                   final HelpersCreator helpersCreator,
                   final ToFhirPrePostProcessorInterface toFhirPrePostProcessor,
@@ -47,7 +45,6 @@ public class ToFhir {
                   final ContentItemCompositionBuilder contentItemCompositionBuilder,
                   final MappingMetricsLogger metricsLogger) {
         this.flatJsonMarshaller = flatJsonMarshaller;
-        this.openEhrApplicationScopedUtils = openEhrApplicationScopedUtils;
         this.gson = gson;
         this.helpersCreator = helpersCreator;
         this.toFhirPrePostProcessor = toFhirPrePostProcessor;

--- a/core/src/main/java/com/syntaric/openfhir/mapping/tofhir/ToFhirPrePostProcessor.java
+++ b/core/src/main/java/com/syntaric/openfhir/mapping/tofhir/ToFhirPrePostProcessor.java
@@ -1,25 +1,37 @@
 package com.syntaric.openfhir.mapping.tofhir;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.util.BundleBuilder;
 import ca.uhn.fhir.util.FhirTerser;
 import com.nedap.archie.rm.composition.Composition;
 import com.nedap.archie.rm.composition.ContentItem;
 import com.syntaric.openfhir.fc.schema.Spec;
 import com.syntaric.openfhir.fc.schema.context.FhirConnectContext;
 import com.syntaric.openfhir.producers.FhirContextRegistry;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.ehrbase.openehr.sdk.webtemplate.model.WebTemplate;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseReference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 public class ToFhirPrePostProcessor implements ToFhirPrePostProcessorInterface {
 
+    final String IPS_PROFILE = "http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips";
+
+    final private boolean containedToSeparateEntites;
+
     final protected FhirContextRegistry fhirContextRegistry;
 
-    public ToFhirPrePostProcessor(final FhirContextRegistry fhirContextRegistry) {
+    public ToFhirPrePostProcessor(final FhirContextRegistry fhirContextRegistry,
+                                  @Value("${openfhir.contained-to-separate-entities:true}") boolean containedToSeparateEntites) {
         this.fhirContextRegistry = fhirContextRegistry;
+        this.containedToSeparateEntites = containedToSeparateEntites;
     }
 
     @Override
@@ -28,7 +40,13 @@ public class ToFhirPrePostProcessor implements ToFhirPrePostProcessorInterface {
                               final List<Composition> compositions,
                               final WebTemplate webTemplate) {
         stripEmptyContained(mappedResource, getVersion(context));
-        return mappedResource;
+
+        if (IPS_PROFILE.equals(context.getContext().getProfile().getUrl())) {
+            // IPS
+            postProcessIps((org.hl7.fhir.r4.model.Bundle) mappedResource);
+        }
+
+        return moveContainedToSeparateEntries(mappedResource, getVersion(context));
     }
 
     @Override
@@ -40,6 +58,101 @@ public class ToFhirPrePostProcessor implements ToFhirPrePostProcessorInterface {
     @Override
     public void preProcessContentItems(FhirConnectContext context, List<ContentItem> contentItems, WebTemplate webTemplate) {
 
+    }
+
+    public IBaseBundle moveContainedToSeparateEntries(final IBaseBundle bundle, final Spec.Version fhirVersion) {
+        if(!containedToSeparateEntites) {
+            return bundle;
+        }
+        final FhirContext ctx = fhirContextRegistry.getContext(fhirVersion);
+        final FhirTerser fhirTerser = ctx.newTerser();
+        final BundleBuilder bundleBuilder = new BundleBuilder(ctx);
+
+        getResourcesFromBundle(bundle, fhirVersion).forEach(resource -> {
+            final List<IBaseReference> allReferences = fhirTerser.getAllPopulatedChildElementsOfType(
+                    resource, IBaseReference.class);
+            bundleBuilder.addCollectionEntry(resource);
+            for (final IBaseReference reference : allReferences) {
+                final IBaseResource containedResource = reference.getResource();
+                if (containedResource == null || containedResource.isEmpty()) {
+                    continue;
+                }
+
+                if (!containedResource.getIdElement().isEmpty()
+                        && !containedResource.getIdElement().getValue().startsWith("#")) {
+                    reference.setReference(String.format("%s/%s", containedResource.fhirType(),
+                            containedResource.getIdElement().getIdPart()));
+                } else {
+                    final String generatedResId = "urn:uuid:" + UUID.randomUUID();
+                    reference.setReference(generatedResId);
+                    containedResource.setId(generatedResId);
+                }
+                bundleBuilder.addCollectionEntry(containedResource);
+                reference.setResource(null);
+            }
+        });
+
+        return copyBundleMetadata(bundle, bundleBuilder.getBundle(), fhirVersion);
+    }
+
+    private IBaseBundle copyBundleMetadata(final IBaseBundle source, final IBaseBundle target,
+                                           final Spec.Version fhirVersion) {
+        switch (fhirVersion) {
+            case STU3 -> {
+                final org.hl7.fhir.dstu3.model.Bundle src = (org.hl7.fhir.dstu3.model.Bundle) source;
+                final org.hl7.fhir.dstu3.model.Bundle tgt = (org.hl7.fhir.dstu3.model.Bundle) target;
+                tgt.setMeta(src.getMeta());
+                if (src.getType() != null) {
+                    tgt.setType(src.getType());
+                }
+                tgt.setIdentifier(src.getIdentifier());
+            }
+            case R4B -> {
+                final org.hl7.fhir.r4b.model.Bundle src = (org.hl7.fhir.r4b.model.Bundle) source;
+                final org.hl7.fhir.r4b.model.Bundle tgt = (org.hl7.fhir.r4b.model.Bundle) target;
+                tgt.setMeta(src.getMeta());
+                if (src.getType() != null) {
+                    tgt.setType(src.getType());
+                }
+                tgt.setTimestamp(src.getTimestamp());
+                tgt.setIdentifier(src.getIdentifier());
+            }
+            case R5 -> {
+                final org.hl7.fhir.r5.model.Bundle src = (org.hl7.fhir.r5.model.Bundle) source;
+                final org.hl7.fhir.r5.model.Bundle tgt = (org.hl7.fhir.r5.model.Bundle) target;
+                tgt.setMeta(src.getMeta());
+                if (src.getType() != null) {
+                    tgt.setType(src.getType());
+                }
+                tgt.setTimestamp(src.getTimestamp());
+                tgt.setIdentifier(src.getIdentifier());
+            }
+            default -> {
+                final org.hl7.fhir.r4.model.Bundle src = (org.hl7.fhir.r4.model.Bundle) source;
+                final org.hl7.fhir.r4.model.Bundle tgt = (org.hl7.fhir.r4.model.Bundle) target;
+                tgt.setMeta(src.getMeta());
+                if (src.getType() != null) {
+                    tgt.setType(src.getType());
+                }
+                tgt.setTimestamp(src.getTimestamp());
+                tgt.setIdentifier(src.getIdentifier());
+            }
+        }
+        return target;
+    }
+
+    private void postProcessIps(final org.hl7.fhir.r4.model.Bundle mappedResource) {
+        mappedResource.setIdentifier(new org.hl7.fhir.r4.model.Identifier().setSystem("urn:oid:2.16.840.1.113883.3.72").setValue(UUID.randomUUID().toString()));
+        mappedResource.setType(org.hl7.fhir.r4.model.Bundle.BundleType.DOCUMENT);
+        mappedResource.getMeta().setProfile(List.of(new org.hl7.fhir.r4.model.CanonicalType("http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips")));
+        mappedResource.setTimestamp(new Date());
+        org.hl7.fhir.r4.model.Composition compositionResource = (org.hl7.fhir.r4.model.Composition) mappedResource.getEntryFirstRep().getResource();
+        if(compositionResource.getDate() == null) {
+            compositionResource.setDate(new Date());
+        }
+        if(compositionResource.getAuthor().isEmpty()) {
+            compositionResource.addAuthor(new org.hl7.fhir.r4.model.Reference().setDisplay("openFHIR"));
+        }
     }
 
     protected Spec.Version getVersion(final FhirConnectContext context) {

--- a/core/src/test/java/com/syntaric/openfhir/mapping/GenericTest.java
+++ b/core/src/test/java/com/syntaric/openfhir/mapping/GenericTest.java
@@ -33,6 +33,7 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.hapi.fluentpath.FhirPathR4;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
 import org.junit.Before;
 import org.mockito.MockitoAnnotations;
 import org.openehr.schemas.v1.OPERATIONALTEMPLATE;
@@ -134,10 +135,9 @@ public abstract class GenericTest {
                 openFhirMapperUtils,
                 (section, context, elapsedMs) -> { /* no-op metrics in tests */ });
         toFhir = new ToFhir(new FlatJsonMarshaller(),
-                new OpenEhrTemplateUtils(),
                 new Gson(),
                 helpersCreator,
-                new ToFhirPrePostProcessor(new FhirContextRegistry()),
+                new ToFhirPrePostProcessor(new FhirContextRegistry(), containedToSeparateEntites()),
                 toFhirMappingEngine,
                 new ContentItemCompositionBuilder(),
                 (section, context, elapsedMs) -> { /* no-op metrics in tests */ });
@@ -170,10 +170,16 @@ public abstract class GenericTest {
 
     protected abstract void prepareState();
 
+    protected boolean containedToSeparateEntites() {
+        return true;
+    }
+
     protected void customMocks() {
 
     }
-
+    protected Resource getBundleEntry(final Bundle bundle, final String id) {
+        return bundle.getEntry().stream().filter(en -> en.getFullUrl() != null && en.getFullUrl().contains(id)).map(Bundle.BundleEntryComponent::getResource).findFirst().orElse(null);
+    }
 
     protected Bundle getTestBundle(String path) {
         InputStream is = getClass().getResourceAsStream(path);

--- a/core/src/test/java/com/syntaric/openfhir/mapping/ips/DiscreteIpsToFhirTest.java
+++ b/core/src/test/java/com/syntaric/openfhir/mapping/ips/DiscreteIpsToFhirTest.java
@@ -63,7 +63,7 @@ public class DiscreteIpsToFhirTest extends GenericTest {
         Assert.assertEquals(1, devicesSection.getEntry().size());
 
         final DeviceUseStatement deviceUseStatement = (DeviceUseStatement) devicesSection.getEntry().stream()
-                .map(e -> e.getResource())
+                .map(e -> getBundleEntry(bundle, e.getReference()))
                 .filter(r -> r instanceof DeviceUseStatement)
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("DeviceUseStatement not found in Medical Devices section"));
@@ -74,7 +74,7 @@ public class DiscreteIpsToFhirTest extends GenericTest {
         Assert.assertEquals("Heart structure", deviceUseStatement.getBodySite().getCodingFirstRep().getDisplay());
         Assert.assertEquals("Heart structure", deviceUseStatement.getBodySite().getText());
 
-        final Device device = (Device) deviceUseStatement.getDevice().getResource();
+        final Device device = (Device) getBundleEntry(bundle, deviceUseStatement.getDevice().getReference());
         Assert.assertNotNull(device);
 
         Assert.assertEquals("Cardiac Pacemaker", device.getDeviceNameFirstRep().getName());
@@ -112,7 +112,7 @@ public class DiscreteIpsToFhirTest extends GenericTest {
         Assert.assertEquals(3, problemSection.getEntry().size());
 
         final List<Condition> conditions = problemSection.getEntry().stream()
-                .map(e -> (Condition) e.getResource())
+                .map(e -> (Condition) getBundleEntry(bundle, e.getReference()))
                 .toList();
         Assert.assertEquals(3, conditions.size());
 
@@ -124,7 +124,7 @@ public class DiscreteIpsToFhirTest extends GenericTest {
         Assert.assertEquals(3, allergySection.getEntry().size());
 
         final List<AllergyIntolerance> allergies = allergySection.getEntry().stream()
-                .map(e -> (AllergyIntolerance) e.getResource())
+                .map(e -> (AllergyIntolerance) getBundleEntry(bundle, e.getReference()))
                 .toList();
         Assert.assertEquals(3, allergies.size());
 

--- a/core/src/test/java/com/syntaric/openfhir/mapping/ips/IpsBidirectionalTest.java
+++ b/core/src/test/java/com/syntaric/openfhir/mapping/ips/IpsBidirectionalTest.java
@@ -8,11 +8,7 @@ import lombok.SneakyThrows;
 import org.apache.commons.io.IOUtils;
 import org.ehrbase.openehr.sdk.serialisation.flatencoding.std.umarshal.FlatJsonUnmarshaller;
 import org.ehrbase.openehr.sdk.webtemplate.parser.OPTParser;
-import org.hl7.fhir.r4.model.AllergyIntolerance;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Condition;
-import org.hl7.fhir.r4.model.Device;
-import org.hl7.fhir.r4.model.DeviceUseStatement;
+import org.hl7.fhir.r4.model.*;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -46,6 +42,8 @@ public class IpsBidirectionalTest extends GenericTest {
                 getFlat(HELPER_LOCATION + FLAT_TEXT_VALUE), new OPTParser(operationaltemplate).parse());
         final Bundle bundle = (Bundle) toFhir.compositionsToFhir(context, List.of(compositionFromFlat), webTemplate);
 
+        Assert.assertEquals(org.hl7.fhir.r4.model.Bundle.BundleType.DOCUMENT, bundle.getType());
+
         final org.hl7.fhir.r4.model.Composition composition = (org.hl7.fhir.r4.model.Composition) bundle.getEntryFirstRep().getResource();
         Assert.assertEquals("http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips", composition.getMeta().getProfile().get(0).getValueAsString());
         Assert.assertEquals("60591-5", composition.getType().getCodingFirstRep().getCode());
@@ -54,9 +52,9 @@ public class IpsBidirectionalTest extends GenericTest {
         Assert.assertEquals("Patient Summary", composition.getTitle());
         Assert.assertEquals("final", composition.getStatusElement().getValueAsString());
 
-        assertProblemList(composition);
-        assertAllergies(composition);
-        assertMedicalDevices(composition);
+        assertProblemList(composition, bundle);
+        assertAllergies(composition, bundle);
+        assertMedicalDevices(composition, bundle);
 
         JsonObject jsonObject = toOpenEhr.fhirToFlatJsonObject(context, bundle, webTemplate);
 
@@ -64,11 +62,13 @@ public class IpsBidirectionalTest extends GenericTest {
                 new Gson().toJson(jsonObject), new OPTParser(operationaltemplate).parse());
         final Bundle roundTwoBundle = (Bundle) toFhir.compositionsToFhir(context, List.of(roundTwoCompositionFromFlat), webTemplate);
 
+        Assert.assertEquals(org.hl7.fhir.r4.model.Bundle.BundleType.DOCUMENT, roundTwoBundle.getType());
+
         final org.hl7.fhir.r4.model.Composition roundTwoComposition = (org.hl7.fhir.r4.model.Composition) roundTwoBundle.getEntryFirstRep().getResource();
 
-        assertProblemList(roundTwoComposition);
-        assertAllergies(roundTwoComposition);
-        assertMedicalDevices(roundTwoComposition);
+        assertProblemList(roundTwoComposition, roundTwoBundle);
+        assertAllergies(roundTwoComposition, roundTwoBundle);
+        assertMedicalDevices(roundTwoComposition, roundTwoBundle);
     }
 
     @Test
@@ -87,8 +87,8 @@ public class IpsBidirectionalTest extends GenericTest {
         Assert.assertEquals("Patient Summary", composition.getTitle());
         Assert.assertEquals("final", composition.getStatusElement().getValueAsString());
 
-        assertProblemList(composition);
-        assertAllergies(composition);
+        assertProblemList(composition, bundle);
+        assertAllergies(composition, bundle);
 
         JsonObject jsonObject = toOpenEhr.fhirToFlatJsonObject(context, bundle, webTemplate);
 
@@ -98,11 +98,12 @@ public class IpsBidirectionalTest extends GenericTest {
 
         final org.hl7.fhir.r4.model.Composition roundTwoComposition = (org.hl7.fhir.r4.model.Composition) roundTwoBundle.getEntryFirstRep().getResource();
 
-        assertProblemList(roundTwoComposition);
-        assertAllergies(roundTwoComposition);
+        assertProblemList(roundTwoComposition, bundle);
+        assertAllergies(roundTwoComposition, bundle);
     }
 
-    private void assertAllergies(org.hl7.fhir.r4.model.Composition composition) {
+    private void assertAllergies(org.hl7.fhir.r4.model.Composition composition,
+                                 final Bundle bundle) {
         final org.hl7.fhir.r4.model.Composition.SectionComponent section = composition.getSection().stream()
                 .filter(s -> s.getCode().getCoding().stream()
                         .anyMatch(c -> "http://loinc.org".equals(c.getSystem()) && "48765-2".equals(c.getCode())))
@@ -124,11 +125,8 @@ public class IpsBidirectionalTest extends GenericTest {
         Assert.assertEquals("48765-2", coding.getCode());
         Assert.assertEquals("Allergies and Intolerances", coding.getDisplay());
 
-        final AllergyIntolerance allergy = (AllergyIntolerance) section.getEntry().stream()
-                .filter(e -> "#3".equals(e.getReference()))
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Entry reference '#3' not found"))
-                .getResource();
+        final AllergyIntolerance allergy = (AllergyIntolerance) getBundleEntry(bundle, section.getEntryFirstRep().getReference());
+
         Assert.assertEquals("inactive", allergy.getClinicalStatus().getCodingFirstRep().getCode());
         Assert.assertEquals("Inactive", allergy.getClinicalStatus().getCodingFirstRep().getDisplay());
         Assert.assertEquals("http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", allergy.getClinicalStatus().getCodingFirstRep().getSystem());
@@ -154,7 +152,8 @@ public class IpsBidirectionalTest extends GenericTest {
         jsonParser.encodeResourceToString(allergy);
     }
 
-    private void assertProblemList(org.hl7.fhir.r4.model.Composition composition) {
+    private void assertProblemList(org.hl7.fhir.r4.model.Composition composition,
+                                   final Bundle bundle) {
         final org.hl7.fhir.r4.model.Composition.SectionComponent section = composition.getSection().stream()
                 .filter(s -> s.getCode().getCoding().stream()
                         .anyMatch(c -> "http://loinc.org".equals(c.getSystem()) && "11450-4".equals(c.getCode())))
@@ -176,19 +175,9 @@ public class IpsBidirectionalTest extends GenericTest {
         Assert.assertEquals("generated", section.getText().getStatusAsString());
         Assert.assertTrue(section.getText().getDivAsString().startsWith("<div xmlns=\"http://www.w3.org/1999/xhtml\"><h5>Problem List</h5><table class=\"hapiPropertyTable\"><thead><tr><th>Condition</th><th>Clinical Status</th><th>Verification Status</th><th>Severity</th><th>Onset</th><th>Abatement</th><th>Notes</th></tr></thead><tbody><tr>"));
 
-        final Condition condition = (Condition) section.getEntry().stream()
-                .filter(e -> "#1".equals(e.getReference()))
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Entry reference '#1' not found"))
-                .getResource();
+        final Condition condition = (Condition) getBundleEntry(bundle, section.getEntry().get(0).getReference());
 
-        final Condition condition2 = (Condition) section.getEntry().stream()
-                .filter(e -> "#2".equals(e.getReference()))
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Entry reference '#2' not found"))
-                .getResource();
-
-        Assert.assertEquals("#1", condition.getId());
+        final Condition condition2 = (Condition) getBundleEntry(bundle, section.getEntry().get(1).getReference());
 
         final org.hl7.fhir.r4.model.Coding verificationCoding = condition.getVerificationStatus().getCoding().stream()
                 .filter(c -> "http://terminology.hl7.org/CodeSystem/condition-ver-status".equals(c.getSystem()))
@@ -245,8 +234,6 @@ public class IpsBidirectionalTest extends GenericTest {
                 .orElseThrow(() -> new AssertionError("note not found"));
 
 
-        Assert.assertEquals("#2", condition2.getId());
-
         Assert.assertTrue(condition2.getVerificationStatus().isEmpty());
 
         final org.hl7.fhir.r4.model.Coding severityCoding2 = condition2.getSeverity().getCoding().stream()
@@ -290,7 +277,8 @@ public class IpsBidirectionalTest extends GenericTest {
                 .orElseThrow(() -> new AssertionError("note not found for condition2"));
     }
 
-    private void assertMedicalDevices(org.hl7.fhir.r4.model.Composition composition) {
+    private void assertMedicalDevices(org.hl7.fhir.r4.model.Composition composition,
+                                      final Bundle bundle) {
         final org.hl7.fhir.r4.model.Composition.SectionComponent section = composition.getSection().stream()
                 .filter(s -> s.getCode().getCoding().stream()
                         .anyMatch(c -> "http://loinc.org".equals(c.getSystem()) && "46264-8".equals(c.getCode())))
@@ -308,14 +296,10 @@ public class IpsBidirectionalTest extends GenericTest {
 
         Assert.assertFalse("Medical Devices section should have at least one entry", section.getEntry().isEmpty());
 
-        final DeviceUseStatement deviceUseStatement = (DeviceUseStatement) section.getEntry().stream()
-                .map(e -> e.getResource())
-                .filter(r -> r instanceof DeviceUseStatement)
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("DeviceUseStatement not found in Medical Devices section"));
+        final DeviceUseStatement deviceUseStatement = (DeviceUseStatement) getBundleEntry(bundle, section.getEntryFirstRep().getReference());
 
         Assert.assertTrue("DeviceUseStatement should have a device reference", deviceUseStatement.hasDevice());
-        final Device device = (Device) deviceUseStatement.getDevice().getResource();
+        final Device device = (Device) getBundleEntry(bundle, deviceUseStatement.getDevice().getReference());
         Assert.assertNotNull("Device resource should be present", device);
 
         Assert.assertFalse("Device should have a deviceName", device.getDeviceName().isEmpty());

--- a/core/src/test/java/com/syntaric/openfhir/mapping/kds/KdsGenericTest.java
+++ b/core/src/test/java/com/syntaric/openfhir/mapping/kds/KdsGenericTest.java
@@ -3,4 +3,8 @@ package com.syntaric.openfhir.mapping.kds;
 import com.syntaric.openfhir.mapping.GenericTest;
 
 public abstract class KdsGenericTest extends GenericTest {
+    @Override
+    protected boolean containedToSeparateEntites() {
+        return false;
+    }
 }

--- a/core/src/test/java/com/syntaric/openfhir/mapping/medicationorder/MedicationOrderToFhirTest.java
+++ b/core/src/test/java/com/syntaric/openfhir/mapping/medicationorder/MedicationOrderToFhirTest.java
@@ -40,7 +40,7 @@ public class MedicationOrderToFhirTest extends GenericTest {
                                                                              new OPTParser(
                                                                                      operationaltemplate).parse());
         final Bundle createdResources = (Bundle) toFhir.compositionsToFhir(context, List.of(composition), webTemplate);
-        Assert.assertEquals(2, createdResources.getEntry().size());
+        Assert.assertEquals(4, createdResources.getEntry().size());
         final MedicationRequest medicationRequestOne = createdResources.getEntry().stream()
                 .map(res -> (MedicationRequest) res.getResource())
                 .filter(res -> res.getNote().stream()
@@ -48,7 +48,7 @@ public class MedicationOrderToFhirTest extends GenericTest {
                 .findFirst()
                 .orElse(null);
         Assert.assertEquals("Lorem ipsum0",
-                            ((Medication) medicationRequestOne.getMedicationReference().getResource()).getCode()
+                            ((Medication) getBundleEntry(createdResources, medicationRequestOne.getMedicationReference().getReference())).getCode()
                                     .getText());
         Assert.assertEquals("21.0",
                             ((Quantity) medicationRequestOne.getDosageInstructionFirstRep().getDoseAndRateFirstRep()
@@ -71,13 +71,14 @@ public class MedicationOrderToFhirTest extends GenericTest {
                                     .getCodingFirstRep().getSystem());
 
         final MedicationRequest medicationRequestTwo = createdResources.getEntry().stream()
+                .filter(res -> res.getResource() instanceof MedicationRequest)
                 .map(res -> (MedicationRequest) res.getResource())
                 .filter(res -> res.getNote().stream()
                         .anyMatch(note -> note.getText().startsWith("Additional instruction on two")))
                 .findFirst()
                 .orElse(null);
         Assert.assertEquals("Lorem ipsum1",
-                            ((Medication) medicationRequestTwo.getMedicationReference().getResource()).getCode()
+                            ((Medication) getBundleEntry(createdResources, medicationRequestTwo.getMedicationReference().getReference())).getCode()
                                     .getText());
         Assert.assertTrue(medicationRequestTwo.getDosageInstruction().isEmpty() || medicationRequestTwo.getDosageInstruction().get(0).isEmpty());
         Assert.assertEquals(3, medicationRequestTwo.getNote().size());

--- a/core/src/test/java/com/syntaric/openfhir/mapping/problemlist/ProblemListToFhirTest.java
+++ b/core/src/test/java/com/syntaric/openfhir/mapping/problemlist/ProblemListToFhirTest.java
@@ -43,8 +43,8 @@ public class ProblemListToFhirTest extends GenericTest {
         final Bundle bundle = (Bundle) toFhir.compositionsToFhir(context, List.of(compositionFromFlat), webTemplate);
 
         final org.hl7.fhir.r4.model.Composition composition = (org.hl7.fhir.r4.model.Composition) bundle.getEntryFirstRep().getResource();
-        final Condition condition = (Condition) composition.getSectionFirstRep().getEntryFirstRep().getResource();
-        final Observation observation = (Observation) condition.getEvidenceFirstRep().getDetailFirstRep().getResource();
+        final Condition condition = (Condition) getBundleEntry(bundle, composition.getSectionFirstRep().getEntryFirstRep().getReference());
+        final Observation observation = (Observation) getBundleEntry(bundle, condition.getEvidenceFirstRep().getDetailFirstRep().getReference());
 
         Assert.assertEquals("Fine", observation.getValueStringType().getValue());
     }
@@ -57,8 +57,8 @@ public class ProblemListToFhirTest extends GenericTest {
         final Bundle bundle = (Bundle) toFhir.compositionsToFhir(context, List.of(compositionFromFlat), webTemplate);
 
         final org.hl7.fhir.r4.model.Composition composition = (org.hl7.fhir.r4.model.Composition) bundle.getEntryFirstRep().getResource();
-        final Condition condition = (Condition) composition.getSectionFirstRep().getEntryFirstRep().getResource();
-        final Observation observation = (Observation) condition.getEvidenceFirstRep().getDetailFirstRep().getResource();
+        final Condition condition = (Condition) getBundleEntry(bundle, composition.getSectionFirstRep().getEntryFirstRep().getReference());
+        final Observation observation = (Observation) getBundleEntry(bundle, condition.getEvidenceFirstRep().getDetailFirstRep().getReference());
 
         final CodeableConcept valueCodeableConcept = observation.getValueCodeableConcept();
         Assert.assertEquals("code", valueCodeableConcept.getCodingFirstRep().getCode());


### PR DESCRIPTION
- IPS post-processing logic, which makes sure Bundle produced is of type `document` and also adds Bundle profile and required Bundle identifier
- engine now by default moves contained Resources to separate Bundle entries (can be changed by setting `openfhir.contained-to-separate-entities` to `false`)
