### PR TITLE
Feeder audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,36 +6,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+
 ## Unreleased
 
 ## [2.2.2] - 2026-05-19
+
 ### Fixed
+
 - ad-hoc Composition generation when a section was given a name and ended up with AQL path name/value=''
 - fhirCondition 'one of' and 'not of' now properly evaluated even if subpath matches
-- `spec.fhirConfig.structureDefinition` in model mappings now implicitly asserts that incoming IBase is of same type (going FHIR->openEHR) and skips a mapping if it's not
+- `spec.fhirConfig.structureDefinition` in model mappings now implicitly asserts that incoming IBase is of same type (
+  going FHIR->openEHR) and skips a mapping if it's not
 - `coded_text_value` leaf type now added when multiple options are possible on a field
 - if a mapping only has manualMappings as children, possible-rm-types should be propagated to the children mappings
 - `DateType` mapping now added (when FHIR field type is https://hl7.org/fhir/R4/datatypes.html#date)
 
 ### Added
+
 - tests for IPS Medical Devices section (unverified mappings)
 - added a docker hub build action that builds arm64 compliant docker image
-- IPS post-processing logic, which makes sure Bundle produced is of type `document` and also adds Bundle profile and required Bundle identifier
+- IPS post-processing logic, which makes sure Bundle produced is of type `document` and also adds Bundle profile and
+  required Bundle identifier
 - support for `DV_PARSABLE` (at the moment, it always assumes |formalism of text/html)
 - narrative generation templates for medical devices and procedures
-- `other_participations` mapping (`perfomer` from/to Reference, `function` from/to DV_TEXT) 
+- `other_participations` mapping (`perfomer` from/to Reference, `function` from/to DV_TEXT)
+- New `feederAudit` custom mapping code: when referenced in a model mapping, automatically serializes data point
+  referenced by `with.fhir` and places it in `feeder_audit`. Formalism is set to `application/fhir+json`.
+  OriginatingSystemAudit.systemId can be passed in as first argument of the mappingCode (i.e.
+  `feederAudit(system-of-mine)`). This is an optional parameter, however if it's not passed in, a value of `openFHIR`
+  will be hardcoded, as it's a required field in openEHR RM. See [blood-pressure.model.yml](core/src/test/resources/blood_pressure/blood-pressure.model.yml) and [blood-pressure-parent.model.yml](core/src/test/resources/blood_pressure/blood-pressure-parent.model.yml) for examples.
 
 ### Changed
-- engine now by default moves contained Resources to separate Bundle entries (can be changed by setting `openfhir.contained-to-separate-entities` to `false`)
-- fhirCondition operator 'type' can now be used also as filtering rather than just conditioning the whole mapping (unless a mapping has no children, then it's only excluding)
-- when adding coded text manual mappings and a field type is `TEXT`, it will be populated properly as coded text 
+
+- engine now by default moves contained Resources to separate Bundle entries (can be changed by setting
+  `openfhir.contained-to-separate-entities` to `false`)
+- fhirCondition operator 'type' can now be used also as filtering rather than just conditioning the whole mapping (
+  unless a mapping has no children, then it's only excluding)
+- when adding coded text manual mappings and a field type is `TEXT`, it will be populated properly as coded text
 
 ## [2.2.1] - 2026-05-04
 
 ### Changed
+
 ### Added
-- `generateNarrative` programmed mapping now accepts an optional second argument specifying a profile URL, e.g. `generateNarrative(entry, http://hl7.org/fhir/StructureDefinition/Condition)`
+
+- `generateNarrative` programmed mapping now accepts an optional second argument specifying a profile URL, e.g.
+  `generateNarrative(entry, http://hl7.org/fhir/StructureDefinition/Condition)`
+
 ### Fixed
+
 - templates for narrative generation are now properly overridable by providing own template
 - condition and allergy narrative templates now correctly filter bundle entries by resource type
 - narrative generation no longer fails with `NoSuchMethodException` when iterating bundle entries
@@ -43,70 +62,91 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [2.2.0] - 2026-05-02
 
 ### Changed
+
 - All openfhir-specific configuration properties now use the `openfhir.` prefix for consistency:
-  - `bootstrap.dir` → `openfhir.bootstrap.dir`
-  - `bootstrap.recursively-open-directories` → `openfhir.bootstrap.recursively-open-directories`
-  - `db.type` → `openfhir.db.type`
-  - behavior when a mappins is only a manual mapping, in which case a NONE is now implied [#54](https://github.com/openFHIR/openfhir/issues/54)
+    - `bootstrap.dir` → `openfhir.bootstrap.dir`
+    - `bootstrap.recursively-open-directories` → `openfhir.bootstrap.recursively-open-directories`
+    - `db.type` → `openfhir.db.type`
+    - behavior when a mappins is only a manual mapping, in which case a NONE is now
+      implied [#54](https://github.com/openFHIR/openfhir/issues/54)
 
 ### Added
+
 - Added mongo indexes to optimize performance
 - memory optimizations
 - `DELETE /opt/{id}` — delete an Operational Template by ID
 - `DELETE /fc/model/{id}` — delete a FHIR Connect model mapper by ID
 - `DELETE /fc/context/{id}` — delete a FHIR Connect context mapper by ID
 - Creating a new release now triggers a workflow publishing Maven packages to GitHub Packages
-- `link` is now a supported keyword in model mapping (although not yet implemented, but mapping creation won't fail if it contains this option)
-- KDS mappings and tests amended to support FhirConnect release1 of the library 
+- `link` is now a supported keyword in model mapping (although not yet implemented, but mapping creation won't fail if
+  it contains this option)
+- KDS mappings and tests amended to support FhirConnect release1 of the library
 - Additional openEHR Data Types for AQL mappings
 - Support for different FHIR versions: STU3, R4 (was supported before), R4B, R5
 - mapping of `|other`
-- New `generateNarrative` custom mapping code: when referenced in a model mapping, automatically generates a FHIR narrative (`text`) on the resource being built during openEHR→FHIR mapping using HAPI's built-in Thymeleaf narrative generator
+- New `generateNarrative` custom mapping code: when referenced in a model mapping, automatically generates a FHIR
+  narrative (`text`) on the resource being built during openEHR→FHIR mapping using HAPI's built-in Thymeleaf narrative
+  generator
 
 ### Fixed
-- `GET /opt/{id}`, `GET /fc/model/{id}`, `GET /fc/context/{id}` now return 404 instead of 200 with empty body when the resource is not found
+
+- `GET /opt/{id}`, `GET /fc/model/{id}`, `GET /fc/context/{id}` now return 404 instead of 200 with empty body when the
+  resource is not found
 - search of opt by templateId now filters properly (before it returned all)
-- `IParser` is now created per-call instead of shared as a singleton, fixing a potential thread-safety issue under concurrent requests
+- `IParser` is now created per-call instead of shared as a singleton, fixing a potential thread-safety issue under
+  concurrent requests
 - when a `manual` mapping has a `fhirCondition`with `$fhirRoot`, this is now correctly evaluated
 - fhircondition `type` is now properly evaluated even when fhirPath has a resolve()
 - fhircondition `type` is now properly evaluated even when Resources are nested in a Bundle
 - when followed-by mapping is referencing a `$resource`, it is now correctly evaluated
 
-
 ## [2.1.0] - 2026-04-07
+
 ### Added
+
 - MappingHelper to the `PrePostFhirInstancePopulator` method signature
 - Added ability to collect metrics for mapping executions (see `MappingMetricsLogger`)
 - `*Manager` as a proxy class inbetween consumers and transactional `*Services`
 
 ### Fixed
+
 - criterias are properly evaluated when multiple (previously only 0th criteria was evaluated)
-- preprocessor fhircondition no longer results in a mapping going openehr->fhir [#35](https://github.com/openFHIR/openfhir/issues/35)                                                                                                                                                                                                            
+- preprocessor fhircondition no longer results in a mapping going openehr->
+  fhir [#35](https://github.com/openFHIR/openfhir/issues/35)
 
 ### Changed
-- `bootstrap.recursively-open-directories` now defaults to true, meaning openfhir engine will go through all directories and subdirectories of the bootstrap location to find mappings and contexts
+
+- `bootstrap.recursively-open-directories` now defaults to true, meaning openfhir engine will go through all directories
+  and subdirectories of the bootstrap location to find mappings and contexts
 
 ## [2.0.5] - 2026-03-23
 
 ### Added
+
 - DV_TEXT can implicitly be mapped to/from DV_CODED_TEXT
 
 ## [2.0.4] - 2026-03-23
 
 ### Fixed
-- when mapping to FHIR Enumeration that's a List (like AllergyIntolerance.category), this is now properly mapped and serialized (previously HAPI serialization was throwing errors)
+
+- when mapping to FHIR Enumeration that's a List (like AllergyIntolerance.category), this is now properly mapped and
+  serialized (previously HAPI serialization was throwing errors)
 - criterias are properly evaluated when multiple (previously only 0th criteria was evaluated)
 
 ### Added
+
 - IPS tests
 - CodedText <> Enumeration mapping
 - Additional sections to IPS mappings and tests on the codebase
 
 ### Changed
+
 - interface on `ToFhirPrePostProcessorInterface.postProcess` now includes also the context, opt and compositions
 
 ## [2.0.3] - 2026-03-20
+
 ### Fixed
+
 - manual mappings may produce duplicate results due to incorrect manual mapping construction
 - fhirpath with fhirconditions was in some cases wrongly constructed, resulting in missin mappings
 - $reference can be suffix with further AQL path when necessary
@@ -114,6 +154,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - logging when something goes wrong in toAql now works (previously stacktrace was not logged)
 
 ### Added
+
 - DV_TEXT maps to CodeableConcept.text
 - ability to transform discrete ContentItems on the fly
 - ehrid is now replaced with the ehrid coming in the request in toAql translation
@@ -121,24 +162,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [2.0.2] - 2026-03-15
 
 ### Added
+
 - tests for toAql translation
 - abbility to translate separate ContentItems not necessarily the whole Composition
 
 ### Fixed
+
 - toAql now properly exposed via RESTful API (/openfhir/toaql), but still a BETA feature
 
 ## [2.0.1] - 2026-03-14
 
 ### Added
+
 - BETA feature of translation of FHIR Search to AQL ([fhir-search-to-aql.md](docs/fhir-search-to-aql.md))
 
 ### Changed
+
 - removed PreAuthorize from openfhir controller (although it didn't have any functionality before either)
 
 ### Fixed
+
 - when a duplicate OPT is trying to be created, server now responds with 400 not 500
-- fixed DV_TEXT (String) to CodeableConcept mapping (now maps to CodeableConcept.text, before it didn't map at all) [issue#13](https://github.com/openFHIR/openfhir/issues/13)
-- when there is more than 1 possible rmType, engine now correctly finds the right one (when openEHR -> FHIR, this is done by deducing rmType based on the data; when going FHIR->openEHR it is based on FHIR type) [issue#14](https://github.com/openFHIR/openfhir/issues/14)
+- fixed DV_TEXT (String) to CodeableConcept mapping (now maps to CodeableConcept.text, before it didn't map at
+  all) [issue#13](https://github.com/openFHIR/openfhir/issues/13)
+- when there is more than 1 possible rmType, engine now correctly finds the right one (when openEHR -> FHIR, this is
+  done by deducing rmType based on the data; when going FHIR->openEHR it is based on FHIR
+  type) [issue#14](https://github.com/openFHIR/openfhir/issues/14)
 
 ## [2.0.0] - 2026-03-01
-Major rewrite of openFHIR, incorporating features from the former commercial version and the open-sourced medblocks/openfhir project, which has now been deprecated in favor of this repository.
+
+Major rewrite of openFHIR, incorporating features from the former commercial version and the open-sourced
+medblocks/openfhir project, which has now been deprecated in favor of this repository.

--- a/core/src/main/java/com/syntaric/openfhir/mapping/custommappings/FeederAuditCustomMapping.java
+++ b/core/src/main/java/com/syntaric/openfhir/mapping/custommappings/FeederAuditCustomMapping.java
@@ -1,0 +1,81 @@
+package com.syntaric.openfhir.mapping.custommappings;
+
+import com.google.gson.JsonObject;
+import com.syntaric.openfhir.fc.schema.Spec;
+import com.syntaric.openfhir.mapping.helpers.DataWithIndex;
+import com.syntaric.openfhir.mapping.helpers.MappingHelper;
+import com.syntaric.openfhir.mapping.tofhir.ToFhirInstantiator;
+import com.syntaric.openfhir.producers.FhirContextRegistry;
+import com.syntaric.openfhir.util.FhirInstanceCreator;
+import com.syntaric.openfhir.util.FhirInstanceCreatorUtility;
+import com.syntaric.openfhir.util.OpenFhirMapperUtils;
+import com.syntaric.openfhir.util.OpenFhirStringUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Custom mapping that generates a FHIR narrative (text) on the resource being built when mapping
+ * openEHR→FHIR. Uses HAPI's built-in Thymeleaf narrative generator.
+ */
+@Slf4j
+@Component
+public class FeederAuditCustomMapping extends CustomMapping {
+
+    private static final Set<String> CODES = Set.of("feederAudit");
+
+    private final FhirContextRegistry fhirContextRegistry;
+    private final ToFhirInstantiator toFhirInstantiator;
+
+    @Autowired
+    public FeederAuditCustomMapping(final FhirContextRegistry fhirContextRegistry,
+                                    final ToFhirInstantiator toFhirInstantiator) {
+        this.fhirContextRegistry = fhirContextRegistry;
+        this.toFhirInstantiator = toFhirInstantiator;
+    }
+
+    public FeederAuditCustomMapping() {
+        this.fhirContextRegistry = new FhirContextRegistry();
+        this.toFhirInstantiator = new ToFhirInstantiator(new FhirInstanceCreator(new OpenFhirStringUtils(),
+                new FhirInstanceCreatorUtility(new OpenFhirStringUtils())));
+    }
+
+    @Override
+    public Set<String> mappingCodes() {
+        return CODES;
+    }
+
+    @Override
+    public DataWithIndex applyOpenEhrToFhirMapping(final MappingHelper mappingHelper,
+                                                   final List<String> joinedValues,
+                                                   final JsonObject valueHolder,
+                                                   final Integer lastIndex,
+                                                   final String path,
+                                                   final String resourceType,
+                                                   final String fhirPath,
+                                                   final OpenFhirStringUtils stringUtils,
+                                                   final OpenFhirMapperUtils mapperUtils) {
+
+
+    }
+
+
+
+
+    private Spec.Version detectVersion(final IBase resource) {
+        if (resource instanceof org.hl7.fhir.dstu3.model.Resource) {
+            return Spec.Version.STU3;
+        }
+        if (resource instanceof org.hl7.fhir.r4b.model.Resource) {
+            return Spec.Version.R4B;
+        }
+        if (resource instanceof org.hl7.fhir.r5.model.Resource) {
+            return Spec.Version.R5;
+        }
+        return Spec.Version.R4;
+    }
+}

--- a/core/src/main/java/com/syntaric/openfhir/mapping/custommappings/FeederAuditCustomMapping.java
+++ b/core/src/main/java/com/syntaric/openfhir/mapping/custommappings/FeederAuditCustomMapping.java
@@ -1,20 +1,26 @@
 package com.syntaric.openfhir.mapping.custommappings;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.fhirpath.IFhirPath;
+import ca.uhn.fhir.util.BundleBuilder;
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.syntaric.openfhir.fc.FhirConnectConst;
 import com.syntaric.openfhir.fc.schema.Spec;
-import com.syntaric.openfhir.mapping.helpers.DataWithIndex;
 import com.syntaric.openfhir.mapping.helpers.MappingHelper;
 import com.syntaric.openfhir.mapping.tofhir.ToFhirInstantiator;
 import com.syntaric.openfhir.producers.FhirContextRegistry;
-import com.syntaric.openfhir.util.FhirInstanceCreator;
-import com.syntaric.openfhir.util.FhirInstanceCreatorUtility;
-import com.syntaric.openfhir.util.OpenFhirMapperUtils;
-import com.syntaric.openfhir.util.OpenFhirStringUtils;
+import com.syntaric.openfhir.util.*;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseReference;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -49,22 +55,125 @@ public class FeederAuditCustomMapping extends CustomMapping {
         return CODES;
     }
 
+    /**
+     * "blood_pressure/blood_pressure/_feeder_audit/originating_system_audit|system_id" : "system id",
+     * "blood_pressure/blood_pressure/_feeder_audit/original_content|formalism" : "plain/text",
+     * "blood_pressure/blood_pressure/_feeder_audit/original_content" : "something",
+     * "blood_pressure/blood_pressure/_feeder_audit/originating_system_item_id:0|id" : "123",
+     * "blood_pressure/blood_pressure/_feeder_audit/feeder_system_item_id:0|id" : "123",
+     * <p>
+     * "blood_pressure/_feeder_audit/original_content" : "something",
+     * "blood_pressure/_feeder_audit/original_content|formalism" : "plain/text",
+     * "blood_pressure/_feeder_audit/feeder_system_item_id:0|id" : "123",
+     * "blood_pressure/_feeder_audit/originating_system_audit|system_id" : "system id",
+     * "blood_pressure/_feeder_audit/originating_system_item_id:0|id" : "123"
+     *
+     */
     @Override
-    public DataWithIndex applyOpenEhrToFhirMapping(final MappingHelper mappingHelper,
-                                                   final List<String> joinedValues,
-                                                   final JsonObject valueHolder,
-                                                   final Integer lastIndex,
-                                                   final String path,
-                                                   final String resourceType,
-                                                   final String fhirPath,
-                                                   final OpenFhirStringUtils stringUtils,
-                                                   final OpenFhirMapperUtils mapperUtils) {
+    public boolean applyFhirToOpenEhrMapping(final MappingHelper mappingHelper,
+                                             final IBase fhirValue,
+                                             final List<String> possibleRmTypes,
+                                             final JsonObject flat,
+                                             final OpenEhrPopulator populator,
+                                             final OpenFhirMapperUtils mapperUtils,
+                                             final OpenFhirStringUtils stringUtils) {
+        final String originatingSystemId = extractArgument(mappingHelper.getProgrammedMapping());
 
+        final Spec.Version version = detectVersion(mappingHelper.getGeneratingFhirResource());
 
+        final List<IBase> toGenerateFeederAuditFrom = getResourceToGenerateFeederAuditFrom(mappingHelper, mappingHelper.getOriginalFhirPath(), version);
+
+        if (toGenerateFeederAuditFrom == null || toGenerateFeederAuditFrom.isEmpty()) {
+            log.warn("feederAudit invoked but fhirPath {} didn't yield any results", mappingHelper.getOriginalFhirPath());
+            return false;
+        }
+        final FhirContext context = fhirContextRegistry.getContext(version);
+        if (toGenerateFeederAuditFrom.size() == 1) {
+            final IBase iBase = toGenerateFeederAuditFrom.get(0);
+            flat.addProperty(getFeederAuditBasePath(mappingHelper.getFullOpenEhrFlatPath()) + "/original_content", context.newJsonParser().encodeToString(iBase));
+        } else {
+            final boolean allAreResources = toGenerateFeederAuditFrom.stream().allMatch(b -> b instanceof IBaseResource);
+            if (allAreResources) {
+                final BundleBuilder bb = new BundleBuilder(context);
+                toGenerateFeederAuditFrom.forEach(r -> bb.addCollectionEntry((IBaseResource) r));
+                flat.addProperty(getFeederAuditBasePath(mappingHelper.getFullOpenEhrFlatPath()) + "/original_content", context.newJsonParser().encodeResourceToString(bb.getBundle()));
+            } else {
+                flat.addProperty(getFeederAuditBasePath(mappingHelper.getFullOpenEhrFlatPath()) + "/original_content", new Gson().toJson(toGenerateFeederAuditFrom));
+            }
+        }
+        flat.addProperty(getFeederAuditBasePath(mappingHelper.getFullOpenEhrFlatPath()) + "/original_content|formalism", "application/fhir+json");
+        flat.addProperty(getFeederAuditBasePath(mappingHelper.getFullOpenEhrFlatPath()) + "/originating_system_audit|system_id", StringUtils.isEmpty(originatingSystemId) ? "openFHIR" : originatingSystemId); // todo: should come from somewhere
+
+        return true;
     }
 
+    private String getFeederAuditBasePath(final String fullOpenEhrPath) {
+        final String withProperUnderscoreFeederAudit = fullOpenEhrPath.replace("feeder_audit", "_feeder_audit");
+        return withProperUnderscoreFeederAudit.endsWith("_feeder_audit") ? withProperUnderscoreFeederAudit : (fullOpenEhrPath + "/_feeder_audit");
+    }
 
+    List<IBase> getResourceToGenerateFeederAuditFrom(final MappingHelper mappingHelper,
+                                                     final String fhirPathForNarrativeGeneration,
+                                                     final Spec.Version version) {
+        if (fhirPathForNarrativeGeneration.equals(FhirConnectConst.FHIR_RESOURCE_FC)) {
+            return Collections.singletonList((IBaseResource) mappingHelper.getGeneratingFhirResource());
+        }
+        if (fhirPathForNarrativeGeneration.equals(FhirConnectConst.FHIR_ROOT_FC)) {
+            return Collections.singletonList((IBaseResource) mappingHelper.getGeneratingFhirRoot());
+        }
+        final IFhirPath fhirPath = fhirContextRegistry.getFhirPath(version);
+        boolean fhirPathOnResource = fhirPathForNarrativeGeneration.startsWith(FhirConnectConst.FHIR_RESOURCE_FC);
+        final Object generatingFhirRoot = fhirPathOnResource ?
+                mappingHelper.getGeneratingFhirResource() : mappingHelper.getGeneratingFhirRoot();
 
+        final String fhirPathForEvaluation = fhirPathOnResource ? fhirPathForNarrativeGeneration.replace(String.format("%s.",
+                FhirConnectConst.FHIR_RESOURCE_FC), "") : fhirPathForNarrativeGeneration;
+
+        final List<IBase> toReturn = new ArrayList<>();
+
+        if (generatingFhirRoot instanceof List listOfGeneratedResources) {
+            for (Object listOfGeneratedResource : listOfGeneratedResources) {
+                final List<IBase> evaluated = fhirPath.evaluate((IBase) listOfGeneratedResource, fhirPathForEvaluation, IBase.class);
+                evaluated.forEach(ev -> {
+                    List<? extends IBase> iBases = resolveReference(ev, mappingHelper, fhirPath);
+                    toReturn.addAll(iBases);
+                });
+            }
+        } else {
+            final List<IBase> evaluated = fhirPath.evaluate((IBase) generatingFhirRoot, fhirPathForEvaluation, IBase.class);
+            if (evaluated.size() == 1) {
+                return Collections.singletonList(resolveReference(evaluated.get(0), mappingHelper, fhirPath).get(0));
+            }
+            evaluated.forEach(ev -> {
+                List<? extends IBase> iBases = resolveReference(ev, mappingHelper, fhirPath);
+                toReturn.addAll(iBases);
+            });
+        }
+        return toReturn;
+    }
+
+    private List<? extends IBase> resolveReference(final IBase toResolveOn,
+                                                   final MappingHelper mappingHelper,
+                                                   final IFhirPath versionedFhirPath) {
+        if ("BundleEntryComponent".equals(toResolveOn.getClass().getSimpleName())
+                || toResolveOn instanceof IBaseReference) {
+            try {
+                final Object resource = toResolveOn.getClass().getMethod("getResource").invoke(toResolveOn);
+                return resource instanceof IBase ? List.of((IBaseResource) resource) : Collections.emptyList();
+            } catch (final Exception e) {
+                log.error("Could not get resource from BundleEntryComponent", e);
+                return Collections.emptyList();
+            }
+        }
+
+        if (FhirConnectConst.REFERENCE.equals(mappingHelper.getOriginalOpenEhrPath())) {
+            return versionedFhirPath.evaluate(toResolveOn, "resolve()", IBaseResource.class);
+        }
+        if (toResolveOn instanceof IBaseResource) {
+            return List.of((IBaseResource) toResolveOn);
+        }
+        return Collections.singletonList(toResolveOn);
+    }
 
     private Spec.Version detectVersion(final IBase resource) {
         if (resource instanceof org.hl7.fhir.dstu3.model.Resource) {

--- a/core/src/main/java/com/syntaric/openfhir/mapping/toopenehr/ToOpenEhrMappingEngine.java
+++ b/core/src/main/java/com/syntaric/openfhir/mapping/toopenehr/ToOpenEhrMappingEngine.java
@@ -276,7 +276,7 @@ public class ToOpenEhrMappingEngine extends BidirectionalMappingEngine {
         }
 
         final boolean result;
-        if (results.isEmpty() || resultsRepresentMissingPrimitiveValues(results)) {
+        if (helper.getProgrammedMapping() == null && (results.isEmpty() || resultsRepresentMissingPrimitiveValues(results))) {
             result = handleMissingResults(helper, flatComposition, toResolveOn, fhirPath, versionedFhirPath, baseClass);
         } else {
             populateOpenEhrForEachResult(helper, flatComposition, toResolveOn, results, fhirPath, indexByHierarchyPath,
@@ -412,6 +412,11 @@ public class ToOpenEhrMappingEngine extends BidirectionalMappingEngine {
 
             recurseIntoChildren(clonedHelper, result, helper, flatComposition, indexByHierarchyPath,
                     baseClass, fhirVersion);
+        }
+
+        if(results.isEmpty() && helper.getProgrammedMapping() != null) {
+            // we still want programmed mapping to happen and within there you can decide what to do
+            invokeProgrammedMapping(helper, flatComposition, null);
         }
     }
 

--- a/core/src/test/java/com/syntaric/openfhir/mapping/bloodpressure/BloodPressureBidirectionalTest.java
+++ b/core/src/test/java/com/syntaric/openfhir/mapping/bloodpressure/BloodPressureBidirectionalTest.java
@@ -1,9 +1,13 @@
 package com.syntaric.openfhir.mapping.bloodpressure;
 
+import com.nedap.archie.rm.archetyped.FeederAudit;
+import com.nedap.archie.rm.archetyped.FeederAuditDetails;
 import com.nedap.archie.rm.composition.Composition;
 import com.nedap.archie.rm.composition.ContentItem;
 import com.nedap.archie.rm.datastructures.Element;
+import com.nedap.archie.rm.datavalues.DvIdentifier;
 import com.nedap.archie.rm.datavalues.DvText;
+import com.nedap.archie.rm.datavalues.encapsulated.DvParsable;
 import com.nedap.archie.rm.datavalues.quantity.DvQuantity;
 import com.nedap.archie.rm.generic.Participation;
 import com.nedap.archie.rm.generic.PartyIdentified;
@@ -45,6 +49,7 @@ public class BloodPressureBidirectionalTest extends GenericTest {
         final Composition composition = new FlatJsonUnmarshaller().unmarshal(getFlat(HELPER_LOCATION + FLAT),
                                                                              webTemplate);
 
+
         // transform it to FHIR
         final Bundle bundle = (Bundle) toFhir.compositionsToFhir(context, List.of(composition), webTemplate);
         BloodPressureToFhirTest.assertBloodPressureFhir(
@@ -67,6 +72,18 @@ public class BloodPressureBidirectionalTest extends GenericTest {
         Assert.assertEquals("name1", ((PartyIdentified) otherParticipations.get(1).getPerformer()).getName());
         Assert.assertEquals("assigner1", ((PartyIdentified) otherParticipations.get(1).getPerformer()).getIdentifiers().get(0).getAssigner());
         Assert.assertEquals("value1", otherParticipations.get(1).getPerformer().getExternalRef().getId().getValue());
+
+        // assert feederAudit
+        final FeederAudit compositionFeederAudit = rmComposition.getFeederAudit();
+        final FeederAudit observationFeederAudit = rmComposition.getContent().get(0).getFeederAudit();
+        Assert.assertEquals("openFHIR", compositionFeederAudit.getOriginatingSystemAudit().getSystemId());
+        Assert.assertEquals("system-of-mine", observationFeederAudit.getOriginatingSystemAudit().getSystemId());
+        final Bundle feederAuditBundle = jsonParser.parseResource(Bundle.class, ((DvParsable) compositionFeederAudit.getOriginalContent()).getValue());
+        final Observation feederAuditObservation = jsonParser.parseResource(Observation.class, ((DvParsable) observationFeederAudit.getOriginalContent()).getValue());
+        Assert.assertEquals(3, feederAuditBundle.getEntry().size());
+        Assert.assertEquals("THIS IS LOCATION OF MEASUREMENT", feederAuditObservation.getBodySite().getText());
+        Assert.assertEquals("application/fhir+json", ((DvParsable) compositionFeederAudit.getOriginalContent()).getFormalism());
+        Assert.assertEquals("application/fhir+json", ((DvParsable) observationFeederAudit.getOriginalContent()).getFormalism());
 
         final String systolicPath = "/content[openEHR-EHR-OBSERVATION.blood_pressure.v2]/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value";
         final String diastolicPath = "/content[openEHR-EHR-OBSERVATION.blood_pressure.v2]/data[at0001]/events[at0006]/data[at0003]/items[at0005]/value";

--- a/core/src/test/resources/blood_pressure/blood-pressure-parent.model.yml
+++ b/core/src/test/resources/blood_pressure/blood-pressure-parent.model.yml
@@ -38,3 +38,9 @@ mappings:
                   fhir: "$fhirRoot"
                   openehr: "$composition/content[openEHR-EHR-OBSERVATION.blood_pressure.v2]"
                 slotArchetype: "OBSERVATION.blood_pressure.v2"
+
+  - name: "feederAudit"
+    with:
+      fhir: "$resource.entry"
+      openehr: "$composition/feeder_audit"
+    mappingCode: "feederAudit"

--- a/core/src/test/resources/blood_pressure/blood-pressure.model.yml
+++ b/core/src/test/resources/blood_pressure/blood-pressure.model.yml
@@ -165,3 +165,10 @@ mappings:
               fhir:
                 - path: "text"
                   value: "THIS IS LOCATION OF MEASUREMENT"
+
+
+  - name: "feederAudit"
+    with:
+      fhir: "$resource"
+      openehr: "$archetype/feeder_audit"
+    mappingCode: "feederAudit(system-of-mine)"


### PR DESCRIPTION
- New `feederAudit` custom mapping code: when referenced in a model mapping, automatically serializes data point
  referenced by `with.fhir` and places it in `feeder_audit`. Formalism is set to `application/fhir+json`.
  OriginatingSystemAudit.systemId can be passed in as first argument of the mappingCode (i.e.
  `feederAudit(system-of-mine)`). This is an optional parameter, however if it's not passed in, a value of `openFHIR`
  will be hardcoded, as it's a required field in openEHR RM. See [blood-pressure.model.yml](core/src/test/resources/blood_pressure/blood-pressure.model.yml) and [blood-pressure-parent.model.yml](core/src/test/resources/blood_pressure/blood-pressure-parent.model.yml) for examples.
