### PR TITLE
values no longer leak between FHIR list entries when the same slot archetype is instantiated more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - support for PARTY_PROXY (from Reference and Idenifier)
 
 ### Fixed
+- toFHIR: values no longer leak between FHIR list entries when the same slot archetype is instantiated
+  more than once. The openEHR occurrence index of a data point (the `0` in `prefix:0`) addresses a
+  position inside the source cluster, not a position in the FHIR list it is being written to, and was
+  being used as the latter. With two instances of the same slot feeding one list — e.g. a Patient's
+  `name` receiving both an official name and a maiden name from two `CLUSTER.structured_name.v1`
+  clusters — the second mapping's index restarted at 0 and overwrote the first entry, so the official
+  name got `use: maiden` and the maiden name lost its `use` entirely. Each entry now binds to the
+  element its own mapping is building. (#90)
 - Non-daily dosage schedules are now reconstructed as `timing.repeat` when mapping to FHIR. Previously the period stored in the openEHR `timing_nondaily.v1` cluster was dropped, leaving the schedule only as prose in `dosage.text` (#95)
 - KDS mappings (test suite) for #93
 - toFHIR: an openEHR `null_flavour` on an ELEMENT is now reconstructed as a FHIR

--- a/core/src/main/java/com/syntaric/openfhir/mapping/tofhir/ToFhirInstantiator.java
+++ b/core/src/main/java/com/syntaric/openfhir/mapping/tofhir/ToFhirInstantiator.java
@@ -44,7 +44,7 @@ public class ToFhirInstantiator {
         }
 
         final String remainingPath = resolveRemainingPath(mappingHelper);
-        final Object instantiated = resolveFromBase(fhirBase, remainingPath, forcingClass, resolveResourceType, index,
+        final Object instantiated = resolveFromBase(fhirBase, remainingPath, forcingClass, resolveResourceType,
                                                     modelPackage);
         return propagateAndReturn(mappingHelper, instantiated);
     }
@@ -82,26 +82,30 @@ public class ToFhirInstantiator {
                                    final String remainingPath,
                                    final String forcingClass,
                                    final String resolveResourceType,
-                                   final int index,
                                    final String modelPackage) {
         if (fhirBase instanceof List<?> fhirBaseList) {
-            return resolveFromList(fhirBaseList, remainingPath, forcingClass, resolveResourceType, index, modelPackage);
+            return resolveFromList(fhirBaseList, remainingPath, forcingClass, resolveResourceType, modelPackage);
         }
         return resolveFromSingle(fhirBase, remainingPath, forcingClass, resolveResourceType, modelPackage);
     }
 
     /**
-     * Resolves the target element from a List base, picking the last element when index is -1.
+     * Resolves the target element from a List base, always against the element the current iteration is
+     * building — the last one.
+     *
+     * <p>The openEHR occurrence index of the data point being mapped (e.g. the {@code 0} in
+     * {@code prefix:0}) addresses a position inside the source cluster, not a position in this FHIR list.
+     * The two only coincide when the list was built one-to-one from that same cluster. When one FHIR list
+     * is fed by several mappings — e.g. a Patient's {@code name} receiving both an official name and a
+     * maiden name from two instances of CLUSTER.structured_name.v1 — each mapping's occurrence index
+     * restarts at 0, so using it here would reach back into an earlier mapping's entry and overwrite it.
      */
     private Object resolveFromList(final List<?> fhirBaseList,
                                    final String remainingPath,
                                    final String forcingClass,
                                    final String resolveResourceType,
-                                   final int index,
                                    final String modelPackage) {
-        final Object listEntry = index == -1
-                ? fhirBaseList.get(fhirBaseList.size() - 1)
-                : fhirBaseList.get(index);
+        final Object listEntry = fhirBaseList.get(fhirBaseList.size() - 1);
         return resolveFromSingle(listEntry, remainingPath, forcingClass, resolveResourceType, modelPackage);
     }
 

--- a/core/src/test/resources/kds/person/toFHIR/output/Patient-mii-exa-test-data-patient-3.json
+++ b/core/src/test/resources/kds/person/toFHIR/output/Patient-mii-exa-test-data-patient-3.json
@@ -52,7 +52,7 @@
         ],
         "name": [
           {
-            "use": "maiden",
+            "use": "official",
             "family": "Schumann",
             "_family": {
               "extension": [
@@ -68,6 +68,7 @@
             ]
           },
           {
+            "use": "maiden",
             "family": "Wieck"
           }
         ],

--- a/core/src/test/resources/kds/person/toFHIR/output/Patient-mii-exa-test-data-patient-5.json
+++ b/core/src/test/resources/kds/person/toFHIR/output/Patient-mii-exa-test-data-patient-5.json
@@ -52,7 +52,7 @@
         ],
         "name": [
           {
-            "use": "maiden",
+            "use": "official",
             "family": "Weber",
             "given": [
               "Sabine",
@@ -60,6 +60,7 @@
             ]
           },
           {
+            "use": "maiden",
             "family": "Müller"
           }
         ],

--- a/core/src/test/resources/kds/person/toFHIR/output/Patient-mii-exa-test-data-patient-7.json
+++ b/core/src/test/resources/kds/person/toFHIR/output/Patient-mii-exa-test-data-patient-7.json
@@ -52,13 +52,14 @@
         ],
         "name": [
           {
-            "use": "maiden",
+            "use": "official",
             "family": "Hoffmann",
             "given": [
               "Anna"
             ]
           },
           {
+            "use": "maiden",
             "family": "Schmidt"
           }
         ],

--- a/core/src/test/resources/kds/person/toFHIR/output/Patient-mii-exa-test-data-patient-9.json
+++ b/core/src/test/resources/kds/person/toFHIR/output/Patient-mii-exa-test-data-patient-9.json
@@ -52,7 +52,7 @@
         ],
         "name": [
           {
-            "use": "maiden",
+            "use": "official",
             "family": "Klein",
             "given": [
               "Petra",
@@ -60,6 +60,7 @@
             ]
           },
           {
+            "use": "maiden",
             "family": "Fischer"
           }
         ],


### PR DESCRIPTION
values no longer leak between FHIR list entries when the same slot archetype is instantiated more than once
#90 