### PR TITLE
toOpenEHR: a `DV_IDENTIFIER`'s `|type` and `|assigner` no longer come…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   share one vocabulary across distributions. It is inert in this project: `classify` never returns it, and the
   `upsert` arm it forces is unreachable.
 
+ ### Fixed
+- toOpenEHR: a `DV_IDENTIFIER`'s `|type` and `|assigner` no longer come back with a placeholder system
+  prepended. On the openEHR → FHIR leg `IdentifierParser` invents the systems
+  `http://openehr.org/identifier/type` and `…/assigner` for parts that carry no system of their own, to record
+  that there was none. Coming back, `buildIdentifierTypeString`/`buildIdentifierAssignerString` re-emitted that
+  placeholder as `system::value` instead of stripping it, so a `|type` of `Prescription number` returned as
+  `http://openehr.org/identifier/type::Prescription number`. `normalizeIdentifierSystem` already did the
+  stripping for `|issuer`, which is why `|id` and `|issuer` round-tripped exactly while these two did not. A
+  system that genuinely came from the source FHIR is unaffected and is still carried across as `system::value`.
+
 ## [2.2.5] - 2026-08-17
 ### Added
 - KDS v1.0 mappings in unit tests

--- a/core/src/main/java/com/syntaric/openfhir/util/OpenEhrPopulator.java
+++ b/core/src/main/java/com/syntaric/openfhir/util/OpenEhrPopulator.java
@@ -42,6 +42,13 @@ public class OpenEhrPopulator {
     );
     private static final String NULL_FLAVOUR_TERMINOLOGY = "openehr";
 
+    /**
+     * Prefix of the placeholder systems {@code IdentifierParser} invents on the openEHR → FHIR leg
+     * for DV_IDENTIFIER parts that carry no system of their own. It marks "no real system", so it has
+     * to be stripped again on the way back rather than surfacing in the openEHR value.
+     */
+    private static final String OPENEHR_IDENTIFIER_SENTINEL_PREFIX = "http://openehr.org/identifier";
+
     private enum NullFlavourAttributes {
         UNKNOWN("unknown", "253"),
         NO_INFORMATION("no information", "271"),
@@ -939,9 +946,8 @@ public class OpenEhrPopulator {
         if (StringUtils.isBlank(system)) {
             return system;
         }
-        final String prefix = "http://openehr.org/identifier";
-        if (system.startsWith(prefix)) {
-            String trimmed = system.substring(prefix.length());
+        if (system.startsWith(OPENEHR_IDENTIFIER_SENTINEL_PREFIX)) {
+            String trimmed = system.substring(OPENEHR_IDENTIFIER_SENTINEL_PREFIX.length());
             while (trimmed.startsWith("/") || trimmed.startsWith("#")) {
                 trimmed = trimmed.substring(1);
             }
@@ -959,10 +965,30 @@ public class OpenEhrPopulator {
         if (StringUtils.isBlank(code)) {
             return null;
         }
-        if (StringUtils.isNotBlank(coding.getSystem())) {
-            return coding.getSystem() + "::" + code;
+        final String system = stripIdentifierSentinelSystem(coding.getSystem());
+        if (StringUtils.isNotBlank(system)) {
+            return system + "::" + code;
         }
         return code;
+    }
+
+    /**
+     * Drops the {@code http://openehr.org/identifier/...} placeholder system that
+     * {@code IdentifierParser} invents on the openEHR → FHIR leg for a DV_IDENTIFIER {@code |type} or
+     * {@code |assigner} that carried no system of its own.
+     * <p>
+     * The placeholder means "there was no real system here", so re-emitting it as
+     * {@code system::value} would corrupt the value on the way back: {@code Prescription number}
+     * would return as {@code http://openehr.org/identifier/type::Prescription number}. This mirrors
+     * what {@link #normalizeIdentifierSystem(String)} already does for {@code |issuer}, which is why
+     * that field round-tripped correctly while these two did not. A genuine system set by the source
+     * FHIR is not affected and is still preserved.
+     */
+    private String stripIdentifierSentinelSystem(final String system) {
+        if (StringUtils.isBlank(system)) {
+            return system;
+        }
+        return system.startsWith(OPENEHR_IDENTIFIER_SENTINEL_PREFIX) ? null : system;
     }
 
     private String buildIdentifierAssignerString(final IBase value) {
@@ -981,8 +1007,9 @@ public class OpenEhrPopulator {
         if (StringUtils.isBlank(chosenValue)) {
             return null;
         }
-        if (StringUtils.isNotBlank(assignerIdSystem)) {
-            return assignerIdSystem + "::" + chosenValue;
+        final String system = stripIdentifierSentinelSystem(assignerIdSystem);
+        if (StringUtils.isNotBlank(system)) {
+            return system + "::" + chosenValue;
         }
         return chosenValue;
     }

--- a/core/src/test/java/com/syntaric/openfhir/util/OpenEhrPopulatorTest.java
+++ b/core/src/test/java/com/syntaric/openfhir/util/OpenEhrPopulatorTest.java
@@ -3,6 +3,8 @@ package com.syntaric.openfhir.util;
 import com.google.gson.JsonObject;
 import com.syntaric.openfhir.fc.FhirConnectConst;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Reference;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,5 +71,62 @@ public class OpenEhrPopulatorTest {
         Assert.assertEquals("masked", flat.get("test/value/null_flavour|value").getAsString());
         Assert.assertEquals("272", flat.get("test/value/null_flavour|code").getAsString());
         Assert.assertEquals("openehr", flat.get("test/value/null_flavour|terminology").getAsString());
+    }
+
+    /**
+     * A DV_IDENTIFIER whose |type and |assigner carried no system of their own gets the
+     * {@code http://openehr.org/identifier/...} placeholder on the way out (see IdentifierParser).
+     * That placeholder means "no real system" and must not surface in the openEHR value on the way
+     * back, the way it already does not for |issuer.
+     */
+    @Test
+    public void identifierPlaceholderSystemIsStrippedOnTheWayBack() {
+        final Identifier identifier = new Identifier();
+        identifier.setValue("RX-SYNTH-000771");
+        identifier.setSystem("http://openehr.org/identifier/Synthetic Clinic Branch");
+        identifier.getType().addCoding(
+                new Coding("http://openehr.org/identifier/type", "Prescription number", null));
+
+        final Reference assigner = new Reference();
+        assigner.setDisplay("Synthetic Clinic Branch");
+        assigner.setIdentifier(new Identifier()
+                                       .setSystem("http://openehr.org/identifier/assigner")
+                                       .setValue("Synthetic Clinic Branch"));
+        identifier.setAssigner(assigner);
+
+        populator.setOpenEhrValue(null, "test/order_identifier", identifier,
+                                  FhirConnectConst.DV_IDENTIFIER, false, flat, null, null);
+
+        Assert.assertEquals("RX-SYNTH-000771", flat.get("test/order_identifier|id").getAsString());
+        Assert.assertEquals("Synthetic Clinic Branch", flat.get("test/order_identifier|issuer").getAsString());
+        Assert.assertEquals("Prescription number", flat.get("test/order_identifier|type").getAsString());
+        Assert.assertEquals("Synthetic Clinic Branch", flat.get("test/order_identifier|assigner").getAsString());
+    }
+
+    /**
+     * A system that genuinely came from the source FHIR is not a placeholder and stays, encoded as
+     * {@code system::value} — stripping it would lose real data.
+     */
+    @Test
+    public void identifierRealSystemIsPreserved() {
+        final Identifier identifier = new Identifier();
+        identifier.setValue("12345");
+        identifier.getType().addCoding(
+                new Coding("http://terminology.hl7.org/CodeSystem/v2-0203", "MR", null));
+
+        final Reference assigner = new Reference();
+        assigner.setDisplay("Some Hospital");
+        assigner.setIdentifier(new Identifier()
+                                       .setSystem("http://example.org/orgs")
+                                       .setValue("HOSP-1"));
+        identifier.setAssigner(assigner);
+
+        populator.setOpenEhrValue(null, "test/order_identifier", identifier,
+                                  FhirConnectConst.DV_IDENTIFIER, false, flat, null, null);
+
+        Assert.assertEquals("http://terminology.hl7.org/CodeSystem/v2-0203::MR",
+                            flat.get("test/order_identifier|type").getAsString());
+        Assert.assertEquals("http://example.org/orgs::HOSP-1",
+                            flat.get("test/order_identifier|assigner").getAsString());
     }
 }


### PR DESCRIPTION
… back with a placeholder syste  prepended